### PR TITLE
Add MIT license and fix documentation links

### DIFF
--- a/EIP-7857-X.md
+++ b/EIP-7857-X.md
@@ -310,4 +310,4 @@ A reference implementation will be provided in the official repository, includin
 
 ## Copyright
 
-Copyright and related rights waived via [MIT License](../LICENSE.md). 
+Copyright and related rights waived via [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Autonoma Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -352,4 +352,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 **Status:** Draft  
 **Type:** Standards Track  
 **Category:** ERC  
-**License:** MIT # autonoma-labs
+**License:** MIT


### PR DESCRIPTION
## Summary
- add missing MIT License file
- update README license link and remove stray comment
- fix license link in EIP-7857-X document

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3dc2acac8326860919490e641af8